### PR TITLE
 Volumania v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-
 # Volumania – Kubernetes volumes on autopilot
 
 **Volumania** is a Kubernetes operator that automatically resizes PersistentVolumeClaims (PVCs) based on their usage.  
-It supports both **manual resizing via CRDs** and **automatic scaling by directly querying Kubernetes node metrics**.
+It supports both **manual resizing via CRDs**, **automatic scaling with CRDs**, and now also **annotation-based autoscaling for PVCs**.
 
 ---
 
@@ -10,8 +9,8 @@ It supports both **manual resizing via CRDs** and **automatic scaling by directl
 
 - 🔧 Manual PVC resizing via `PVCManualResize` CRD  
 - 🚀 Automated PVC scaling with thresholds, step sizes and max sizes  
+- 🏷️ Annotation-based PVC autoscaling without writing CRDs yourself  
 - 🧩 No Prometheus required – directly uses the Kubernetes kubelet metrics API  
-
 
 ---
 
@@ -67,9 +66,11 @@ helm install volumania volumania/volumania -f my-values.yaml
 
 ---
 
-## 🧾 CRD Examples
+## 🧾 Usage
 
-### Manual PVC Resize
+You now have **three ways** to let Volumania autoscale your PVCs:
+
+### 1. Manual PVC Resize
 
 ```yaml
 apiVersion: scaling.volumania.io/v1
@@ -81,7 +82,7 @@ spec:
   newSize: 20Gi
 ```
 
-### PVC AutoScaler
+### 2. PVC AutoScaler (via CRD)
 
 ```yaml
 apiVersion: scaling.volumania.io/v1
@@ -98,6 +99,44 @@ spec:
   cooldownSeconds: 60         # Wait at least 60 seconds between resizes
 ```
 
+### 3. PVC AutoScaler (via Annotations)
+
+Instead of creating a CRD manually, you can enable autoscaling directly on a PVC using annotations:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-data
+  namespace: default
+  annotations:
+    volumania.io/autoscaler.enabled: "true"
+    volumania.io/autoscaler.stepSize: "2Gi"   # required
+    volumania.io/autoscaler.maxSize: "50Gi"   # required
+    # optional: will default to current size if not set
+    volumania.io/autoscaler.minSize: "10Gi"
+    # optional: custom Prometheus query
+    volumania.io/autoscaler.promQuery: "my_prometheus_query"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard
+```
+
+#### When to use annotations?
+Annotation-based autoscaling is especially useful when:
+- You don’t want to manage CRDs manually  
+- PVCs are created automatically by higher-level controllers such as:
+  - **StatefulSets**  
+  - **Operators** (e.g. PostgreSQL, Kafka, Elasticsearch)  
+  - **Helm charts** where PVC templates are embedded  
+- You want autoscaling to be declared **close to the PVC itself** for clarity  
+
+In these cases, Volumania will detect the annotations and automatically create and manage the underlying `PVCAutoScaler` CR for you.
+
 ---
 
 ## 🧪 Development
@@ -113,14 +152,14 @@ kopf run --standalone --all-namespaces controllers/main.py
 
 ## 📄 License
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+Licensed under the Apache License, Version 2.0 (the "License");  
+you may not use this file except in compliance with the License.  
 You may obtain a copy of the License at:
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
+Unless required by applicable law or agreed to in writing, software  
+distributed under the License is distributed on an "AS IS" BASIS,  
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  
+See the License for the specific language governing permissions and  
 limitations under the License.

--- a/controllers/handlers/pvc_autoscaler_from_annotation.py
+++ b/controllers/handlers/pvc_autoscaler_from_annotation.py
@@ -1,0 +1,215 @@
+# Copyright 2025 Volumania
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kopf
+import kubernetes
+from kubernetes.client import ApiException
+from utils.k8s import resolve_min_size, is_smaller_or_equal, is_valid_quantity
+
+# ---- Annotation keys ----
+ANNOT_PREFIX = "volumania.io/autoscaler."
+ANNOT_ENABLED = ANNOT_PREFIX + "enabled"
+ANNOT_STEP    = ANNOT_PREFIX + "stepSize"
+ANNOT_MAX     = ANNOT_PREFIX + "maxSize"
+ANNOT_MIN     = ANNOT_PREFIX + "minSize"
+ANNOT_QUERY   = ANNOT_PREFIX + "promQuery"
+
+# ---- CRD config ----
+GROUP   = "scaling.volumania.io"
+VERSION = "v1"
+PLURAL  = "pvcautoscalers"
+KIND    = "PVCAutoScaler"
+FIELD_MANAGER = "volumania-annotation-controller"
+
+
+def autoscaler_name(namespace: str, pvc_name: str) -> str:
+    """
+    Generate a deterministic PVCAutoScaler name for a PVC.
+
+    Args:
+        namespace (str): The namespace where the PVC resides.
+        pvc_name (str): The name of the PVC.
+
+    Returns:
+        str: Lowercased deterministic PVCAutoScaler resource name.
+    """
+    return f"autoscaler-{namespace}-{pvc_name}".lower()
+
+
+def build_pvc_autoscaler_body(namespace: str, pvc_name: str, cfg: dict, name: str) -> dict:
+    """
+    Build the PVCAutoScaler custom resource body (CR spec).
+
+    Args:
+        namespace (str): Namespace of the PVC and PVCAutoScaler.
+        pvc_name (str): Name of the PVC.
+        cfg (dict): Validated autoscaler configuration.
+        name (str): Name of the PVCAutoScaler resource.
+
+    Returns:
+        dict: A dictionary representing the PVCAutoScaler manifest.
+    """
+    spec = {"pvcName": pvc_name, "namespace": namespace}
+    spec.update({k: v for k, v in cfg.items() if v is not None})
+    return {
+        "apiVersion": f"{GROUP}/{VERSION}",
+        "kind": KIND,
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": spec,
+    }
+
+
+def _warn(pvc_obj, logger, msg: str):
+    """
+    Emit a Kubernetes warning event and log an error message.
+
+    Args:
+        pvc_obj (dict): The PVC object where the event should be attached.
+        logger (kopf.Logger): Kopf logger instance.
+        msg (str): Warning/error message to log and attach as an event.
+    """
+    try:
+        kopf.event(pvc_obj, type="Warning", reason="AutoscalerConfigError", message=msg)
+    finally:
+        logger.error(f"[PVC-Autoscaling]{msg}")
+
+
+def _build_cfg_from_annotations(pvc_obj, logger):
+    """
+    Extract and validate autoscaler configuration from PVC annotations.
+
+    Args:
+        pvc_obj (dict): The PVC object with metadata and annotations.
+        logger (kopf.Logger): Kopf logger instance.
+
+    Returns:
+        dict | str | None:
+            - dict: Valid configuration with stepSize, maxSize, minSize, and optional metrics.
+            - "ERROR": If annotations are invalid or missing required fields.
+            - None: If autoscaler is disabled.
+    """
+    meta = pvc_obj.get("metadata") or {}
+    ns   = meta.get("namespace")
+    pvc  = meta.get("name")
+    ann  = meta.get("annotations") or {}
+
+    if not ann or ann.get(ANNOT_ENABLED) != "true":
+        return None
+
+    step_size = (ann.get(ANNOT_STEP) or "").strip()
+    if not step_size:
+        _warn(pvc_obj, logger, f"'{ANNOT_STEP}' is required and missing/empty.")
+        return "ERROR"
+
+    max_size = (ann.get(ANNOT_MAX) or "").strip()
+    if not max_size:
+        _warn(pvc_obj, logger, f"'{ANNOT_MAX}' is required and missing/empty.")
+        return "ERROR"
+
+    min_size = resolve_min_size(ns, pvc, ann.get(ANNOT_MIN))
+    if not min_size:
+        _warn(pvc_obj, logger, "PVC size could not be determined for minSize.")
+        return "ERROR"
+
+    if not is_valid_quantity(step_size):
+        _warn(pvc_obj, logger, f"'{ANNOT_STEP}' has invalid format: '{step_size}'")
+        return "ERROR"
+    if not is_valid_quantity(max_size):
+        _warn(pvc_obj, logger, f"'{ANNOT_MAX}' has invalid format: '{max_size}'")
+        return "ERROR"
+    if not is_valid_quantity(min_size):
+        _warn(pvc_obj, logger, f"'{ANNOT_MIN}' has invalid format: '{min_size}'")
+        return "ERROR"
+
+    try:
+        if not is_smaller_or_equal(min_size, max_size):
+            _warn(pvc_obj, logger, f"'{ANNOT_MIN}' ({min_size}) must be ≤ '{ANNOT_MAX}' ({max_size}).")
+            return "ERROR"
+    except Exception as e:
+        _warn(pvc_obj, logger, f"Size comparison failed: {e}")
+        return "ERROR"
+
+    cfg = {"stepSize": step_size, "maxSize": max_size, "minSize": min_size}
+    prom = (ann.get(ANNOT_QUERY) or "").strip()
+    if prom:
+        cfg["metrics"] = {"promQuery": prom}
+    return cfg
+
+
+def apply_autoscaler_for_pvc(pvc_obj, logger):
+    """
+    Create, patch, or delete a PVCAutoScaler CR for a given PVC
+    based on its autoscaler annotations.
+
+    Args:
+        pvc_obj (dict): The PVC object including metadata and annotations.
+        logger (kopf.Logger): Kopf logger instance.
+    """
+    meta = pvc_obj.get("metadata") or {}
+    ns   = meta.get("namespace")
+    pvc  = meta.get("name")
+
+    cfg = _build_cfg_from_annotations(pvc_obj, logger)
+    name = autoscaler_name(ns, pvc)
+    api = kubernetes.client.CustomObjectsApi()
+
+    if cfg is None:
+        try:
+            api.delete_namespaced_custom_object(GROUP, VERSION, ns, PLURAL, name)
+            logger.info(f"Deleted {KIND} {ns}/{name} (disabled)")
+        except ApiException as e:
+            if e.status != 404:
+                raise
+        return
+
+    if cfg == "ERROR":
+        return
+
+    body = build_pvc_autoscaler_body(ns, pvc, cfg, name)
+
+    try:
+        api.patch_namespaced_custom_object(
+            group=GROUP,
+            version=VERSION,
+            namespace=ns,
+            plural=PLURAL,
+            name=name,
+            body=body,
+        )
+        logger.info(f"Applied {KIND} {ns}/{name}")
+    except ApiException as e:
+        if e.status == 404:
+            api.create_namespaced_custom_object(
+                group=GROUP, version=VERSION, namespace=ns, plural=PLURAL, body=body
+            )
+            logger.info(f"Created {KIND} {ns}/{name}")
+        else:
+            raise
+
+
+@kopf.on.event("", "v1", "persistentvolumeclaims")
+def pvc_event(event, logger, **_):
+    """
+    Kopf event handler for PVCs.
+    Reacts to creation and modification events to reconcile PVCAutoScaler resources.
+
+    Args:
+        event (dict): Kubernetes event containing the PVC object.
+        logger (kopf.Logger): Kopf logger instance.
+        **_: Additional args provided by Kopf (ignored).
+    """
+    etype = event.get("type")
+    obj   = event.get("object") or {}
+    if etype in ("ADDED", "MODIFIED"):
+        apply_autoscaler_for_pvc(obj, logger)

--- a/controllers/main.py
+++ b/controllers/main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import kopf
-from handlers import manual_resize, autoscaler
+from handlers import manual_resize, autoscaler, pvc_autoscaler_from_annotation
 import logging
 
 # Optional: Global init/logging hooks

--- a/controllers/utils/k8s.py
+++ b/controllers/utils/k8s.py
@@ -3,7 +3,7 @@ import os
 import re
 import requests
 import urllib3
-from typing import Any
+from typing import Optional, Dict, Any
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -256,3 +256,28 @@ def fetch_all_pvc_usages_from_cluster() -> list[dict[str, Any]]:
             print(f"❌ Failed to scrape node {node.metadata.name}: {e}")
 
     return all_usages
+
+def is_valid_quantity(size_str: str) -> bool:
+    """Check if a size string is a valid K8s-like quantity according to parse_size()."""
+    try:
+        parse_size(size_str)
+        return True
+    except Exception:
+        return False
+
+def resolve_min_size(namespace: str, pvc_name: str, annotated_min: Optional[str]) -> Optional[str]:
+    """
+    Resolve minSize for a PVC:
+    - If annotated_min is a non-empty string, return it as-is.
+    - Otherwise, fetch the current PVC requested size from the cluster.
+    - Returns None if the current size cannot be determined.
+    """
+    val = (annotated_min or "").strip()
+    if val:
+        return val
+    try:
+        cur = get_pvc_size(namespace, pvc_name)
+        cur = (cur or "").strip()
+        return cur or None
+    except Exception:
+        return None


### PR DESCRIPTION
# 🚀 Volumania v0.4.0 – Annotation-based PVC Autoscaling

## ✨ New Features
- **Annotation-based PVC Autoscaler**  
  You can now enable autoscaling directly on a PVC without creating a `PVCAutoScaler` CRD.  
  Simply add annotations to your PVC:  
  ```yaml
  metadata:
    annotations:
      volumania.io/autoscaler.enabled: "true"
      volumania.io/autoscaler.stepSize: "2Gi"
      volumania.io/autoscaler.maxSize: "50Gi"
  ```
  - `stepSize` and `maxSize` are required  
  - `minSize` defaults to the PVC’s current size if not set  
  - optional `promQuery` for custom metrics  
  - Volumania automatically creates and manages the underlying CRD  

- **Automatic reconciliation on PVC changes**  
  - Adding or updating annotations will update the `PVCAutoScaler`  
  - Removing the annotations disables autoscaling and deletes the CR  

## 🎯 Why this matters
- Ideal for **StatefulSets**, **Operators** (Postgres, Kafka, Elasticsearch, …) and **Helm charts**, where PVCs are generated automatically.  
- Keeps configuration **close to the PVC** and avoids writing extra CRDs.  

## 🛠 Improvements
- Better validation of annotation values (invalid configs now produce clear warning events).  
- More robust error handling for CR creation/patching.  
- Change Logging

